### PR TITLE
Clarify enable assisted installer

### DIFF
--- a/modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc
+++ b/modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc
@@ -3,9 +3,9 @@
 // * scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
 
 [id="enabling-assisted-installer-service-on-bare-metal_{context}"]
-= Enabling the assisted service and updating AgentServiceConfig on the hub cluster
+= Enabling the assisted service
 
-{rh-rhacm-first} uses the assisted service to deploy {product-title} clusters. The assisted service is deployed automatically when you enable the MultiClusterHub Operator with Central Infrastructure Management (CIM). When you have enabled CIM on the hub cluster, you then need to update the `AgentServiceConfig` custom resource (CR) with references to the ISO and RootFS images that are hosted on the mirror registry HTTP server.
+{rh-rhacm-first} uses the assisted service to deploy {product-title} clusters. The assisted service is deployed automatically when you enable the MultiClusterHub on {rh-rhacm-first}. After that, you need to configure Provisioning to look every Namespace and, to update the `AgentServiceConfig` custom resource (CR) with references to the ISO and RootFS images that are hosted on the mirror registry HTTP server.
 
 .Prerequisites
 
@@ -13,9 +13,11 @@
 
 * You have logged in to the hub cluster as a user with `cluster-admin` privileges.
 
-* You have enabled the Central Infrastructure Management service on the hub cluster.
+* You have {rh-rhacm-first} with MultiClusterHub enabled.
 
 .Procedure
+
+. Enable the Provisioning to use all Namespaces and configure mirrors if disconnected 
 
 . Update the `AgentServiceConfig` CR by running the following command:
 +

--- a/modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc
+++ b/modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc
@@ -17,7 +17,7 @@
 
 .Procedure
 
-. Enable the Provisioning to use all Namespaces and configure mirrors if disconnected 
+. Enable the Provisioning to use all Namespaces and configure mirrors if disconnected. https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#enable-cim[See more here]
 
 . Update the `AgentServiceConfig` CR by running the following command:
 +


### PR DESCRIPTION
 Trying to simplify the documentation:

-   If CIM is enabled by default with the Multiclusterhub. Then, the requirement is only the MultiClusterHub. We dont mention CIM and this would make reading easier.
-  Then you only need the, pre-required (Multiclusterhub) installed operator to look to all the Namespaces.

Not mentioning CIM would make easier to read.

